### PR TITLE
added commented out deps example to deps.edn for scratch project

### DIFF
--- a/resources/org/corfield/new/scratch/root/deps.edn
+++ b/resources/org/corfield/new/scratch/root/deps.edn
@@ -1,1 +1,5 @@
-{}
+{
+  ;; :deps {
+  ;;   org.example/lib {:mvn/version "x.x.x"}
+  ;; }
+}


### PR DESCRIPTION
it might be useful to have a copy/pastable example of adding lib dependencies in deps.edn. Probably not only for a scrach project though.