### PR TITLE
deps.edn: added codox to check doc beforehand + minor doc fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,4 +22,10 @@
                 org.clojure/test.check {:mvn/version "1.1.3"}
                 io.github.cognitect-labs/test-runner
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                slipset/deps-deploy {:mvn/version "0.2.2"}}}}}
+                slipset/deps-deploy {:mvn/version "0.2.2"}}}
+  :codox
+  {:extra-deps {codox/codox {:mvn/version "0.10.8"}}
+   :exec-fn codox.main/generate-docs
+   :exec-args {:source-paths ["src"]
+               :metadata {:doc/format :markdown}
+               :codox {:writer codox.writer.html/write-docs}}}}}

--- a/src/org/corfield/new/transformers.clj
+++ b/src/org/corfield/new/transformers.clj
@@ -4,12 +4,12 @@
   "Built-in transformers to support conditional template generation,
    based on CLI options:
 
-   :data-fn transformers:
+   `:data-fn` transformers:
 
    * choose-test-runner -- if `:test-runner :lazytest` is specified, add the
      coordinates etc for LazyTest, else add Cognitect's `test-runner`
 
-   :template-fn transformers:
+   `:template-fn` transformers:
 
    * maybe-add-bb -- if `:build :bb` is specified, use the `build-bb`
      templates folder (instead of the default `build` folder)")


### PR DESCRIPTION
This is a small PR which adds [codox](https://github.com/weavejester/codox) as an alias. Running it with the following command generates a `target/doc` folder with HTML docs:

`clojure -X:codox`

This HTML output is useful to check how the doc will look like before creating a PR or so.