### PR TITLE
address #70 by merging license info after template fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+* v0.11.1 in progress
+  * Address [#70](https://github.com/seancorfield/deps-new/issues/70) by supporting `:license/id` in `template.edn` files.
+
 * v0.11.0 8629dcc -- 2026-03-04
   * Add `clojure -X:codox` to `deps.edn` so folks can generate API documentation (since cljdoc does not work with source releases on GitHub yet), see PR [#69](https://github.com/seancorfield/deps-new/pull/69) from [@fmjrey](https://github.com/fmjrey).
   * License is now retrieved from SPDX library, default EPL-1.0 can easily be changed with the `:license/id` option, see PR [#68](https://github.com/seancorfield/deps-new/pull/68) from [@fmjrey](https://github.com/fmjrey).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# deps-new [![Slack](https://img.shields.io/badge/slack-deps--new-yellow.svg?logo=slack)](https://clojurians.slack.com/app_redirect?channel=deps-new)
+# deps-new
 
 Create new projects for use with the Clojure CLI and `deps.edn`.
+
+Discuss on [![Slack](https://img.shields.io/badge/slack-deps--new-yellow.svg?logo=slack)](https://clojurians.slack.com/app_redirect?channel=deps-new).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ are generated with an open source `LICENSE` file and have a **License** section 
 `README.md` files does not mean you need to keep that license in place, if you do not
 want your project to be open source.
 
+**Template authors can specify a default license** in their `template.edn` files using
+the `:license/id` key. This allows the generated projects to automatically use
+the specified license unless overridden by the user.
+
 **Choosing a license**: the use of the Eclipse Public License v1.0 is a tradition that
 started with Leiningen's `lein new` and carried over into `boot new` and now `clj-new`.
 The idea is that it's better to ensure any open source projects created have a valid

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -20,6 +20,9 @@ for substitutions that can be overridden via the command-line. Keys that match t
 derived from the project name or the environment should not be used -- the derived
 variables will override them.
 
+In particular, you can provide defaults for any `deps-new` options by specifying
+them in your `template.edn` file, e.g., `:license-id Apache-2.0`.
+
 For any unqualified key computed from the project name or supplied on the command-line
 that has a string as its value, an `{{opt/ns}}` version is also available that should
 be suitable for use as a namespace in the generated code, and an `{{opt/file}}` version
@@ -28,7 +31,7 @@ that should be suitable for use as a filename or directory path.
 ## Making your template work remotely
 
 If you wish to deploy and use your template from a remote git repository, a `template.edn` and
-`root` directory alone aren't sufficient. You will also need to package it in a deps.edn project,
+`root` directory alone aren't sufficient. You will also need to package it in a `deps.edn` project,
 so `deps-new` can consume it.
 
 It will look for `root` and `template.edn` under something like `resources/myusername/mytemplate/`

--- a/src/org/corfield/new/impl.clj
+++ b/src/org/corfield/new/impl.clj
@@ -244,7 +244,6 @@
         username   (or (System/getenv "USER")
                        (System/getProperty "user.name"))]
     (merge name-data
-           (licenses/id->license opts)
            {:developer  (str/capitalize username)
             :git-dir    (when git-dir
                           (cond-> git-dir
@@ -294,13 +293,15 @@
                        ;; :template-fn result is replacement:
                        ((requiring-resolve template-fn) edn opts))
                      basic-edn
-                     (get-multi-option basic-edn :template-fn))]
+                     (get-multi-option basic-edn :template-fn))
+        desc {:description (str "FIXME: my new"
+                                (when-let [template-name (:template opts)]
+                                  (str " " template-name))
+                                " project.")}
+        merged-opts (merge desc edn opts)]
     ;; this allows any defaults from the template to
     ;; be part of the data used for substitution:
-    [(merge {:description (str "FIXME: my new"
-                               (when-let [template-name (:template opts)]
-                                 (str " " template-name))
-                               " project.")} edn opts) edn]))
+    [(merge merged-opts (licenses/id->license merged-opts)) edn]))
 
 (comment
   (find-root [] 'org.corfield.new/app)


### PR DESCRIPTION
This adds the license info _after_ applying template fns, so that `template.edn` should be able to set (override) the default license to be used.